### PR TITLE
[FIX] connector_prestashop_catalog_manager: impact_price rounding

### DIFF
--- a/connector_prestashop_catalog_manager/models/product_product/exporter.py
+++ b/connector_prestashop_catalog_manager/models/product_product/exporter.py
@@ -151,13 +151,14 @@ class ProductCombinationExportMapper(Component):
         else:
             extra_to_export = record.impact_price
         tax = record.taxes_id[:1]
+        # 6 is the rounding precision used by PrestaShop for the
+        # tax excluded price.
         if tax.price_include and tax.amount_type == "percent":
-            # 6 is the rounding precision used by PrestaShop for the
-            # tax excluded price.  we can get back a 2 digits tax included
-            # price from the 6 digits rounded value
+            # we can get back a 2 digits tax included price
+            # from the 6 digits rounded value
             return {"price": round(extra_to_export / self._get_factor_tax(tax), 6)}
         else:
-            return {"price": extra_to_export}
+            return {"price": round(extra_to_export, 6)}
 
     @changed_by("standard_price")
     @mapping


### PR DESCRIPTION
6 is the rounding precision used by PrestaShop.

Error occurred because of pricelist price rounding via method __get_products_price_ 

https://hive.versada.eu/projects/metalurga-support-maintenance/work_packages/22978/activity