### PR TITLE
[IMP] connector_prestashop: dict to xml

### DIFF
--- a/connector_prestashop/README.rst
+++ b/connector_prestashop/README.rst
@@ -33,7 +33,7 @@ If you want to export from Odoo to PrestaShop changes made on the products,
 product categories or product images, you need to install
 *connector_prestashop_catalog_manager* module in this same repository.
 
-This connector supports PrestaShop version up to 1.6.11. Maybe later versions
+This connector supports PrestaShop version up to 1.7.x.0. Maybe later versions
 are also supported, but they haven't been tested. It uses the webservices of
 PrestaShop.
 

--- a/connector_prestashop/__manifest__.py
+++ b/connector_prestashop/__manifest__.py
@@ -19,6 +19,7 @@
             "freezegun",
             "vcrpy",
             "bs4",
+            "dicttoxml",
         ],
     },
     "author": "Akretion,"

--- a/connector_prestashop/components/backend_adapter.py
+++ b/connector_prestashop/components/backend_adapter.py
@@ -4,6 +4,7 @@ import base64
 import logging
 from contextlib import contextmanager
 
+from dicttoxml import dicttoxml
 from prestapyt import PrestaShopWebServiceDict, PrestaShopWebServiceError
 from requests.exceptions import (
     ConnectionError as ConnError,
@@ -230,7 +231,12 @@ class GenericAdapter(AbstractComponent):
             str(attributes),
         )
         res = self.client.add(
-            self._prestashop_model, {self._export_node_name: attributes}
+            self._prestashop_model,
+            dicttoxml(
+                {self._export_node_name: attributes},
+                custom_root="prestashop",
+                attr_type=False,
+            ),
         )
         if self._export_node_name_res:
             return res["prestashop"][self._export_node_name_res]["id"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # generated from manifests external_dependencies
 bs4
+dicttoxml
 freezegun
 html2text
 prestapyt


### PR DESCRIPTION
From PS 8.x versions, our used prestapyt is no longer converting to xml correctly when passing dict (valid structure changes). 
We are converting to correct XML format from our side.

Related issue: https://github.com/prestapyt/prestapyt/issues/69

23977