### PR TITLE
[FIX] connector_prestashop: 1.7.x.0 key

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,13 +13,13 @@ jobs:
   pre-commit:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
       - name: Get python version
         run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/pre-commit
           key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}

--- a/connector_prestashop/components/version_key.py
+++ b/connector_prestashop/components/version_key.py
@@ -125,7 +125,7 @@ class VersionKey17x0(Component):
     _usage = "prestashop.version.key.1.7.x.0"
 
     keys = {
-        "product_option_value": "product_option_value",
+        "product_option_value": "product_option_values",
         "category": "category",
         "image": "image",
         "order_slip": "order_slip",


### PR DESCRIPTION
25496

This value is correct with prestashop version 8 and 1.7.6.0.

tests will fail as dependency modules are not in OCA branches yet